### PR TITLE
Feature/remove conn interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 log*
 test/test
+test/server/server
+test/client/client

--- a/buffstreams.go
+++ b/buffstreams.go
@@ -138,14 +138,11 @@ func handleListenedConn(address string, conn *net.TCPConn, headerByteSize int, m
 				} else {
 					// Client closed the conn
 					log.Printf("Address %s: Client closed connection during header read. Underlying error: %s", address, headerReadError)
-					log.Printf("Error when trying to read from address %s. Tried to read %d, actually read %d. Underlying error: %s", address, headerByteSize, totalHeaderBytesRead, headerReadError)
-
 				}
 			}
 			conn.Close()
 			return
 		}
-		log.Print("NO ERROR!")
 		// Now turn that buffer of bytes into an integer - represnts size of message body
 		msgLength, bytesParsed := binary.Uvarint(headerBuffer)
 		iMsgLength := int(msgLength)
@@ -330,7 +327,7 @@ func (bm *BuffManager) WriteTo(address string, data []byte, persist bool) (int, 
 		totalBytesWritten += bytesWritten
 	}
 
-	if writeError != nil || persist {
+	if writeError != nil || !persist {
 		if writeError != nil && bm.enableLogging {
 			log.Printf("Error while writing data to %s. Expected to write %d, actually wrote %d. Underlying error: %s", address, len(toWrite), totalBytesWritten, writeError)
 		}

--- a/buffstreams.go
+++ b/buffstreams.go
@@ -209,7 +209,6 @@ func readFromConnection(reader *net.TCPConn, buffer []byte) (int, error) {
 		if err != nil && err == io.EOF {
 			// "End of individual transmission"
 			// We're just done reading from that conn
-			log.Print("Error not nil and EOF")
 			return bytesLen, err
 		}
 	}
@@ -218,7 +217,6 @@ func readFromConnection(reader *net.TCPConn, buffer []byte) (int, error) {
 		//"Underlying network failure?"
 		// Not sure what this error would be, but it could exist and i've seen it handled
 		// as a general case in other networking code. Following in the footsteps of (greatness|madness)
-		log.Printf("Error not nil: %s", err)
 		return bytesLen, err
 	}
 	// Read some bytes, return the length

--- a/test/test.go
+++ b/test/test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"github.com/StabbyCutyou/buffstreams"
+	"github.com/StabbyCutyou/buffstreams/test/message"
+	"github.com/golang/protobuf/proto"
 	"log"
 	"strconv"
 	"time"
@@ -19,7 +21,14 @@ func main() {
 		EnableLogging:  true,
 	}
 	// 100 byte message
-	msg := []byte("HeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyHeyheyheyH!")
+	name := "Stabby"
+	date := time.Now().UnixNano()
+	data := "This is an intenntionally long and rambling sentence to pad out the size of the message."
+	msg := &message.Note{Name: &name, Date: &date, Comment: &data}
+	msgBytes, err := proto.Marshal(msg)
+	if err != nil {
+		log.Print(err)
+	}
 	startingPort := 5031
 	bm := buffstreams.New(cfg)
 	bm.StartListening(strconv.Itoa(startingPort), TestCallback)
@@ -29,10 +38,11 @@ func main() {
 			address := buffstreams.FormatAddress("127.0.0.1", port)
 			count := 0
 			for {
-				_, err := bm.WriteTo(address, msg, true)
-				if err != nil {
-					log.Printf("Error %s", err)
-				}
+				written, err := bm.WriteTo(address, msgBytes, true)
+				log.Printf("Wrote %d Bytes of %d + 2, error was: %s", written, len(msgBytes), err)
+				//if err != nil {
+				//	log.Printf("Error %s", err)
+				//}
 				count = count + 1
 				log.Printf("%d - %d", n, count)
 			}

--- a/test/test.go
+++ b/test/test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/StabbyCutyou/buffstreams/test/message"
 	"github.com/golang/protobuf/proto"
 	"log"
+	"net"
 	"strconv"
 	"time"
 )
@@ -38,16 +39,78 @@ func main() {
 			address := buffstreams.FormatAddress("127.0.0.1", port)
 			count := 0
 			for {
-				written, err := bm.WriteTo(address, msgBytes, true)
-				log.Printf("Wrote %d Bytes of %d + 2, error was: %s", written, len(msgBytes), err)
-				//if err != nil {
-				//	log.Printf("Error %s", err)
-				//}
+				_, err := bm.WriteTo(address, msgBytes, true)
+				//log.Printf("Wrote %d Bytes of %d + 2, error was: %s", written, len(msgBytes), err)
+				if err != nil {
+					log.Printf("Error %s", err)
+				}
 				count = count + 1
 				log.Printf("%d - %d", n, count)
 			}
 		}(i, strconv.Itoa(startingPort), bm)
 		//startingPort = startingPort + 1
 	}
+	time.Sleep(time.Minute * 10)
+}
+
+func testTCPConns() {
+	// Start Listening
+	go func() {
+		//readTicker := time.NewTicker(10 * time.Millisecond)
+		tcpAddr, err := net.ResolveTCPAddr("tcp", ":5031")
+		if err != nil {
+			log.Print(err)
+			return
+		}
+		receiveSocket, err := net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			log.Print(err)
+			return
+		}
+
+		conn, err := receiveSocket.AcceptTCP()
+		if err != nil {
+			log.Printf("Error attempting to accept connection: %s", err)
+		} else {
+			buffer := make([]byte, 10)
+			for {
+				//select {
+				// Check to see if we have a tick
+				//case <-readTicker.C:
+				log.Print("Trying to read")
+				bytesRead, err := conn.Read(buffer)
+				log.Printf("Bytes Read: %d out of %d", bytesRead, 10)
+				if err != nil {
+					log.Printf("Error: %s", err)
+				}
+				//}
+			}
+		}
+	}()
+
+	// Start writing
+	go func() {
+		writeTicker := time.NewTicker(10 * time.Second)
+		tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:5031")
+		if err != nil {
+			log.Print(err)
+			return
+		}
+		bytes := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		conn, err := net.DialTCP("tcp", nil, tcpAddr)
+		for {
+			select {
+			// Check to see if we have a tick
+			case <-writeTicker.C:
+				log.Printf("%s", time.Now())
+				bytesWritten, err := conn.Write(bytes)
+				log.Printf("Bytes Written: %d out of %d", bytesWritten, 10)
+				if err != nil {
+					log.Printf("Error: %s", err)
+				}
+			}
+		}
+	}()
+
 	time.Sleep(time.Minute * 10)
 }


### PR DESCRIPTION
This fixes a bug in how persist is treated, and removes using any of the interface level stuff for networking, going straight TCP as was the intention.